### PR TITLE
Change the method to get the ApiServer hostname

### DIFF
--- a/pkg/operator/certrotationcontroller/externalloadbalancer.go
+++ b/pkg/operator/certrotationcontroller/externalloadbalancer.go
@@ -21,7 +21,8 @@ func (c *CertRotationController) syncExternalLoadBalancerHostnames() error {
 		return nil
 	}
 	hostname = strings.Replace(hostname, "https://", "", 1)
-	hostname = hostname[0:strings.LastIndex(hostname, ":")]
+	hostname_arr := strings.Split(hostname, ":")
+	hostname = hostname_arr[0]
 
 	klog.V(2).Infof("syncing external loadbalancer hostnames: %v", hostname)
 	c.externalLoadBalancer.setHostnames([]string{hostname})


### PR DESCRIPTION
The  kube-apiserver operator is going to degraded state while changing ApiServer URL in Infrastructure config.

Note: _If there is no port specified_

Ref:
https://github.com/openshift/cluster-kube-apiserver-operator/blob/master/pkg/operator/certrotationcontroller/externalloadbalancer.go#L24

I0511 16:20:50.553418       1 servicehostname.go:40] syncing servicenetwork hostnames: [172.30.0.1 kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local openshift openshift.default openshift.default.svc openshift.default.svc.cluster.local]
I0511 16:20:50.553446       1 panic.go:679] Finished waiting for CertRotation
I0511 16:20:50.553456       1 panic.go:679] Shutting down CertRotation
panic: runtime error: slice bounds out of range [:-1]

goroutine 271 [running]:
github.com/openshift/cluster-kube-apiserver-operator/pkg/operator/certrotationcontroller.(*CertRotationController).syncExternalLoadBalancerHostnames(0xc000a980a0, 0x0, 0x0)
	github.com/openshift/cluster-kube-apiserver-operator@/pkg/operator/certrotationcontroller/externalloadbalancer.go:24 +0x295
